### PR TITLE
Fix dummy_new_proof creation for type_of_consensus == 6

### DIFF
--- a/new_consensus_module.py
+++ b/new_consensus_module.py
@@ -347,7 +347,7 @@ def generate_new_block(transactions, generator_id, previous_hash, type_of_consen
         new_block['Header']['hash'] = encryption_module.hashing_function(new_block['Body'])
     if type_of_consensus == 4:
         new_block['Header']['PoET'] = ''
-    if type_of_consensus == 5:
+    if type_of_consensus == 6:
         new_block['Header']['dummy_new_proof'] = dummy_proof_generator_function(new_block)
     return new_block
 


### PR DESCRIPTION
This PR fixes an error where the dummy_new_proof key was not generated when type_of_consensus == 6, leading to an access error later in the code. The issue was caused by an incorrect conditional check (type_of_consensus == 5), which has now been updated to type_of_consensus == 6.